### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,4 +1,7 @@
 name: Restyled
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/InfernapeXavier/InfernapeXavier.github.io/security/code-scanning/1](https://github.com/InfernapeXavier/InfernapeXavier.github.io/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow creates or updates pull requests (using `peter-evans/create-pull-request`), it needs `contents: read` and `pull-requests: write`. The best way to do this is to add the `permissions` block at the workflow root (top-level, after `name:` and before `on:`), so it applies to all jobs unless overridden. No changes to the steps or jobs are needed; only the addition of the `permissions` block is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
